### PR TITLE
Fix assigning new created customer to the order

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -13,6 +13,7 @@ class Config
     private const IS_ENABLED = 'hyva_themes_checkout/new_customer/enable';
     private const SEND_RESET_PASSWORD_MAIL = 'hyva_themes_checkout/new_customer/send_reset_password_mail';
     private const NEW_PASSWORD_TEMPLATE = 'hyva_themes_checkout/new_customer/create_password_template';
+    private const DEFAULT_CUSTOMER_GROUP_XML_PATH = 'customer/create_account/default_group';
 
     public function __construct(private ScopeConfigInterface $scopeConfig)
     {
@@ -39,6 +40,15 @@ class Config
         return $this->scopeConfig->getValue(
             self::NEW_PASSWORD_TEMPLATE,
             ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    public function getDefaultCustomerGroup(?int $storeId = null): int
+    {
+        return (int)$this->scopeConfig->getValue(
+            self::DEFAULT_CUSTOMER_GROUP_XML_PATH,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
         );
     }
 }

--- a/Observer/ConvertGuestToCustomer.php
+++ b/Observer/ConvertGuestToCustomer.php
@@ -58,6 +58,10 @@ class ConvertGuestToCustomer implements ObserverInterface
             // Ideally we should make this configurable.
             ->setCustomerGroupId(\Magento\Customer\Api\Data\GroupInterface::NOT_LOGGED_IN_ID);
 
+        /** @var \Magento\Sales\Model\Order $order */
+        $order = $observer->getEvent()->getOrder();
+        $order->setCustomerId($customer->getId());
+
         if ($this->newAccountConfig->sendPasswordMailEnabled()) {
             $this->sendPasswordResetEmail($customer->getEmail());
         }

--- a/Observer/ConvertGuestToCustomer.php
+++ b/Observer/ConvertGuestToCustomer.php
@@ -56,7 +56,7 @@ class ConvertGuestToCustomer implements ObserverInterface
         $quote->setCustomerId($customer->getId())
             ->setCustomerIsGuest(0)
             // Ideally we should make this configurable.
-            ->setCustomerGroupId(\Magento\Customer\Api\Data\GroupInterface::NOT_LOGGED_IN_ID);
+            ->setCustomerGroupId($this->newAccountConfig->getDefaultCustomerGroup((int)$quote->getStoreId()));
 
         /** @var \Magento\Sales\Model\Order $order */
         $order = $observer->getEvent()->getOrder();


### PR DESCRIPTION
Fix assigning new created customer to the order

test FP: https://github.com/Vendic/koene/pull/192

Problem description:
current module is creating new customer account on `sales_model_service_quote_submit_before` event. 
Also in same observer it is setting new customer id to quote, so that it be saved to order also.
But customer id setting to order happens before `sales_model_service_quote_submit_before` event dispatched. Because of that, order was not getting customer id.

Proposition:
I also noticed that it is setting "Not logged in" customer group in quote (with comment to make configuration for this)
I think it would be nice just to set default customer group in that place (from Stores -> Configuration -> Customers -> Customer Configuration -> Create New Account Options -> Default Group)
@Tjitse-E what do you think?