### PR TITLE
Fix missing root tag error

### DIFF
--- a/view/frontend/templates/magewire/create-account.phtml
+++ b/view/frontend/templates/magewire/create-account.phtml
@@ -6,14 +6,9 @@
 /** @var \Vendic\HyvaCheckoutCreateAccount\Magewire\CreateAccount $magewire */
 /** @var \Vendic\HyvaCheckoutCreateAccount\ViewModel\GuestChecker $guestCheckerViewModel */
 $guestCheckerViewModel = $viewModels->require(\Vendic\HyvaCheckoutCreateAccount\ViewModel\GuestChecker::class);
-
-if (!$guestCheckerViewModel->isCustomerGuest()) {
-    return;
-}
-
 ?>
 <div>
-    <?php if (!$magewire->accountExists): ?>
+    <?php if ($guestCheckerViewModel->isCustomerGuest() && !$magewire->accountExists): ?>
         <div class="flex gap-x-4">
             <div class="flex items-center">
                 <?= $block->getChildHtml('checkbox') ?>


### PR DESCRIPTION
With Hyvä Checkout 1.1.16, I get this as a logged in customer:

![image](https://github.com/Vendic/hyva-checkout-create-account/assets/930199/a6133ad8-6c65-420d-858a-930a6f6b9227)
