### PR TITLE
Allows to select email template used when sending email

### DIFF
--- a/Model/EmailSender.php
+++ b/Model/EmailSender.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright   Copyright (c) Vendic B.V https://vendic.nl/
+ */
+
+namespace Vendic\HyvaCheckoutCreateAccount\Model;
+
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Mail\Template\SenderResolverInterface;
+use Magento\Framework\Mail\Template\TransportBuilder;
+use Magento\Framework\Math\Random;
+use Magento\Customer\Api\AccountManagementInterface;
+use Magento\Customer\Model\AccountManagement;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+use Vendic\HyvaCheckoutCreateAccount\Model\Config;
+
+class EmailSender
+{
+    private const DEFAULT_STORE_ID = 0;
+    private const LOG_PREFIX = '[Vendic_HyvaCheckoutCreateAccount]';
+
+    public function __construct(
+        private StoreManagerInterface $storeManager,
+        private LoggerInterface $logger,
+        private Config $newAccountConfig,
+        private SenderResolverInterface $senderResolver,
+        private ScopeConfigInterface $scopeConfig,
+        private TransportBuilder $transportBuilder,
+        private Random $mathRandom,
+        private AccountManagementInterface $accountManagement,
+    ) {
+    }
+
+    public function sendPasswordResetEmail(CustomerInterface $customer): void
+    {
+        $email = $customer->getEmail();
+        $templateId = $this->newAccountConfig->getNewPasswordTemplate();
+
+        if (!$email || !$templateId) {
+            $this->logger->error(sprintf('%s No email or template', self::LOG_PREFIX));
+            return;
+        }
+
+        try {
+            $newPasswordToken = $this->mathRandom->getUniqueHash();
+            $this->accountManagement->changeResetPasswordLinkToken($customer, $newPasswordToken);
+
+            $resetUrl = $this->getResetPasswordUrl($newPasswordToken, $this->getStoreId(), (int)$customer->getId());
+
+            $this->transportBuilder
+                ->setTemplateIdentifier($templateId)
+                ->setTemplateOptions(['area' => Area::AREA_FRONTEND, 'store' => $this->getStoreId()])
+                ->setTemplateVars([
+                    'customer_name' => $customer->getFirstname() . ' ' . $customer->getLastname(),
+                    'reset_password_url' => $resetUrl
+                ])
+                ->setFromByScope($this->getEmailSenderFrom())
+                ->addTo($email)
+                ->getTransport()
+                ->sendMessage();
+        } catch (\Exception $e) {
+            $this->logger->error(
+                sprintf('%s Email send failed: %s', self::LOG_PREFIX, $e->getMessage())
+            );
+        }
+    }
+
+    private function getResetPasswordUrl(string $token, int $storeId, int $customerId): string
+    {
+        return $this->storeManager->getStore($storeId)
+            ->getUrl(
+                'customer/account/createPassword',
+                [
+                    '_query' => [
+                        'id' => $customerId,
+                        'token' => $token
+                    ],
+                    '_secure' => true,
+                    '_nosid' => 1
+                ]
+            );
+    }
+
+    private function getStoreId(): int
+    {
+        try {
+            return (int)$this->storeManager->getStore()->getId();
+        } catch (\Exception $e) {
+            $this->logger->error(sprintf('%s Store Id failed: %s', self::LOG_PREFIX, $e->getMessage()));
+            return self::DEFAULT_STORE_ID;
+        }
+    }
+
+    private function getEmailSenderFrom(): array
+    {
+        return $this->senderResolver->resolve(
+            $this->scopeConfig->getValue(
+                AccountManagement::XML_PATH_FORGOT_EMAIL_IDENTITY,
+                ScopeInterface::SCOPE_STORES
+            )
+        );
+    }
+}

--- a/Observer/ConvertGuestToCustomer.php
+++ b/Observer/ConvertGuestToCustomer.php
@@ -18,6 +18,7 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use Psr\Log\LoggerInterface;
 use Vendic\HyvaCheckoutCreateAccount\Magewire\Checkbox;
 use Vendic\HyvaCheckoutCreateAccount\Model\Config;
+use Vendic\HyvaCheckoutCreateAccount\Model\EmailSender;
 
 class ConvertGuestToCustomer implements ObserverInterface
 {
@@ -28,7 +29,8 @@ class ConvertGuestToCustomer implements ObserverInterface
         private StoreManagerInterface $storeManager,
         private CheckoutSession $checkoutSession,
         private LoggerInterface $logger,
-        private Config $newAccountConfig
+        private Config $newAccountConfig,
+        private EmailSender $emailSender,
     ) {
     }
 
@@ -63,7 +65,7 @@ class ConvertGuestToCustomer implements ObserverInterface
         $order->setCustomerId($customer->getId());
 
         if ($this->newAccountConfig->sendPasswordMailEnabled()) {
-            $this->sendPasswordResetEmail($customer->getEmail());
+            $this->emailSender->sendPasswordResetEmail($customer);
         }
     }
 
@@ -84,21 +86,6 @@ class ConvertGuestToCustomer implements ObserverInterface
                 sprintf('Could not create customer %s from quote: %s', $email, $e->getMessage())
             );
             return null;
-        }
-    }
-
-    private function sendPasswordResetEmail(string $email): void
-    {
-        try {
-            $this->accountManagement->initiatePasswordReset(
-                $email,
-                AccountManagement::EMAIL_RESET,
-                $this->storeManager->getStore()->getWebsiteId()
-            );
-        } catch (Exception $e) {
-            $this->logger->error(
-                sprintf('Could not send password reset email to %s: %s', $email, $e->getMessage())
-            );
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ composer require vendic/hyva-checkout-create-account
 ```
 
 ## Configuration
-None at this moment. Feel free to create a pull request if you need specific settings. Check the [issues](https://github.com/Vendic/hyva-checkout-create-account/issues) for tickets that need help.
+This module introduces a configuration section under **Stores > Configuration > Hyvä Themes > Checkout > New Customer** with the following options:
+
+- **Enable New Customer**: Enables the "create account" checkbox on the checkout page.
+- **Send Reset Password Mail**: If enabled, a reset password email will be sent after the customer account is created.
+- **Create Password Template**: Allows you to select the email template used when sending the reset password mail.
+
+Feel free to create a pull request if you need additional configuration options. Check the [issues](https://github.com/Vendic/hyva-checkout-create-account/issues) for tickets that need help.
 
 ## Compatibility
 - [Hyvä Themes](https://www.hyva.io/hyva-themes-license.html) ^1.0

--- a/etc/email_templates.xml
+++ b/etc/email_templates.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Email:etc/email_templates.xsd">
-    <template id="hyva_themes_checkout_new_customer_create_password_template" label="Create Password" file="password_reset.html" type="html" module="Magento_Customer" area="frontend"/>
+    <template
+        id="hyva_themes_checkout_new_customer_create_password_template"
+        label="Create Password"
+        file="password_new_on_create_account.html"
+        type="html"
+        module="Vendic_HyvaCheckoutCreateAccount"
+        area="frontend"/>
 </config>

--- a/view/frontend/email/password_new_on_create_account.html
+++ b/view/frontend/email/password_new_on_create_account.html
@@ -1,0 +1,29 @@
+<!--@subject {{trans "Reset your %store_name password" store_name=$store.frontend_name}} @-->
+<!--@vars {
+"var store.frontend_name":"Store Name",
+"var customer_name":"Customer Name",
+"var reset_password_url":"Password Reset URL"
+} @-->
+{{template config_path="design/email/header_template"}}
+
+<p class="greeting">{{trans "%name," name=$customer_name}}</p>
+<p>{{trans "There was recently a request to change the password for your account."}}</p>
+<p>{{trans "If you requested this change, set a new password here:"}}</p>
+
+<table class="button" width="100%" border="0" cellspacing="0" cellpadding="0">
+    <tr>
+        <td>
+            <table class="inner-wrapper" border="0" cellspacing="0" cellpadding="0" align="center">
+                <tr>
+                    <td align="center">
+                        <a href="{{var reset_password_url}}" target="_blank">{{trans "Set a New Password"}}</a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+<p>{{trans "If you did not make this request, you can ignore this email and your password will remain the same."}}</p>
+
+{{template config_path="design/email/footer_template"}}


### PR DESCRIPTION
Replaces the default `initiatePasswordReset()` with a custom implementation.

- Adds `EmailSender` class to generate a reset token and send the reset email manually.
- Uses configurable email template and sender.
